### PR TITLE
Adding some hooks for binder usage of notebooks

### DIFF
--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,1 @@
+jupyter nbextension enable --py --sys-prefix ipyleaflet

--- a/postBuild
+++ b/postBuild
@@ -1,1 +1,3 @@
+#!/bin/bash
+pip install ipyleaflet
 jupyter nbextension enable --py --sys-prefix ipyleaflet


### PR DESCRIPTION
This PR adds a `postBuild` file so that it can be executing using binder for demos.

Launch the example binder jupyterlab environment with this link:
https://mybinder.org/v2/gh/CSIRO-enviro-informatics/DGGSForPoly/ipyleaflet-binder

Users can then run through the `poly_fill_usage.ipynb` notebook with ipyleaflet.